### PR TITLE
Fixes for future cupy errors

### DIFF
--- a/pykilosort/cptools.py
+++ b/pykilosort/cptools.py
@@ -384,7 +384,7 @@ def median(a, axis=0):
     else:
         indexer[axis] = slice(index - 1, index + 1)
 
-    return cp.mean(part[indexer], axis=axis)
+    return cp.mean(part[tuple(indexer)], axis=axis)
 
 
 def var(x):

--- a/pykilosort/learn.py
+++ b/pykilosort/learn.py
@@ -866,7 +866,7 @@ def learnAndSolve8b(ctx, sanity_plots=False, plot_widgets=None, plot_pos=None):
     # from the past that were averaged to give rise to the current template
     pmi = cp.exp(
         -1.0 / cp.linspace(params.momentum[0], params.momentum[1], niter - nBatches)
-    )
+    ).get()
 
     Nsum = min(Nchan, 7)  # how many channels to extend out the waveform in mexgetspikes
     # lots of parameters passed into the CUDA scripts

--- a/pykilosort/utils.py
+++ b/pykilosort/utils.py
@@ -70,7 +70,7 @@ def _extend(x, i0, i1, val, axis=0):
         assert x.shape[axis] == i1
     s = [slice(None, None, None)] * x.ndim
     s[axis] = slice(i0, i1, 1)
-    x[s] = val
+    x[tuple(s)] = val
     for i in range(x.ndim):
         if i != axis:
             assert x.shape[i] == shape[i]


### PR DESCRIPTION
Certain syntax changes in upstream cupy version cause pyks2 to throw an error, and also affect the sorting. These are small changes, pertaining to implicit indexing of cupy arrays using arrays. 