### PR TITLE
minor bug fix: delete cached traces after preprocess

### DIFF
--- a/pykilosort/gui/data_view_box.py
+++ b/pykilosort/gui/data_view_box.py
@@ -505,7 +505,8 @@ class DataViewBox(QtWidgets.QGroupBox):
         self.clear_cached_traces()
         self.clear_cached_whitening_matrix()
 
-    def clear_cached_traces(self):
+    @QtCore.pyqtSlot(object)
+    def clear_cached_traces(self, _=None):
         self.whitened_traces = None
         self.residual_traces = None
         self.prediction_traces = None

--- a/pykilosort/gui/main.py
+++ b/pykilosort/gui/main.py
@@ -164,6 +164,8 @@ class KiloSortGUI(QtWidgets.QMainWindow):
         self.run_box.disableInput.connect(self.disable_all_input)
         self.run_box.sortingStepStatusUpdate.connect(self.update_sorting_status)
         self.run_box.updateProbeView.connect(self.update_probe_view)
+        self.run_box.updateDataView.connect(self.data_view_box.set_whitening_matrix)
+        self.run_box.updateDataView.connect(self.data_view_box.clear_cached_traces)
 
     def change_channel_display(self, direction):
         if self.context is not None:

--- a/pykilosort/gui/run_box.py
+++ b/pykilosort/gui/run_box.py
@@ -7,6 +7,7 @@ from pykilosort.gui.sorter import KiloSortWorker
 class RunBox(QtWidgets.QGroupBox):
     updateContext = QtCore.pyqtSignal(object)
     updateProbeView = QtCore.pyqtSignal()
+    updateDataView = QtCore.pyqtSignal(object)
     sortingStepStatusUpdate = QtCore.pyqtSignal(dict)
     disableInput = QtCore.pyqtSignal(bool)
 
@@ -119,6 +120,7 @@ class RunBox(QtWidgets.QGroupBox):
     def finished_preprocess(self, context):
         self.updateContext.emit(context)
         self.updateProbeView.emit()
+        self.updateDataView.emit(context.intermediate.Wrot)
         self.set_sorting_step_status("preprocess", True)
 
     @QtCore.pyqtSlot(object)

--- a/pykilosort/gui/settings_box.py
+++ b/pykilosort/gui/settings_box.py
@@ -92,6 +92,7 @@ class SettingsBox(QtWidgets.QGroupBox):
             self.min_firing_rate_input,
             self.threshold_lower_input,
             self.threshold_upper_input,
+            self.lambda_value_input,
             self.auc_splits_input,
         ]
 


### PR DESCRIPTION
Cached traces based on pre-good_channels_calculation and an approx. whitening matrix are now deleted after preprocessing, so that the new whitening matrix is used for subsequent called to update_plot.