### PR TITLE
seamlessly re-sort within GUI

### DIFF
--- a/pykilosort/gui/main.py
+++ b/pykilosort/gui/main.py
@@ -7,7 +7,6 @@ from pykilosort import __version__
 from pykilosort.gui import (
     DataViewBox,
     HeaderBox,
-    KiloSortWorker,
     MessageLogBox,
     ProbeViewBox,
     RunBox,
@@ -290,6 +289,7 @@ class KiloSortGUI(QtWidgets.QMainWindow):
 
     @QtCore.pyqtSlot(dict)
     def update_sorting_status(self, status_dict):
+        self.run_box.change_sorting_status(status_dict)
         self.data_view_box.change_sorting_status(status_dict)
         self.probe_view_box.change_sorting_status(status_dict)
 

--- a/pykilosort/gui/probe_view_box.py
+++ b/pykilosort/gui/probe_view_box.py
@@ -128,9 +128,6 @@ class ProbeViewBox(QtWidgets.QGroupBox):
     def change_sorting_status(self, status_dict):
         self.sorting_status = status_dict
 
-    def change_sorting_status(self, status_dict):
-        self.sorting_status = status_dict
-
     def generate_spots_list(self):
         spots = []
         size = 10

--- a/pykilosort/gui/sorter.py
+++ b/pykilosort/gui/sorter.py
@@ -110,6 +110,8 @@ class KiloSortWorker(QtCore.QThread):
 
     def run(self):
         if "preprocess" in self.steps:
+            self.context.reset()
+            self.context.probe = self.context.raw_probe.copy()
             self.context = run_preprocess(self.context)
             self.finishedPreprocess.emit(self.context)
 


### PR DESCRIPTION
Allows the user to correctly go through the sorting over and over through the GUI if need be. 

* deletes intermediate files for previous sorting when restarting from the "preprocess" step
* includes a warning for this if intermediate files are found and if the user doesn't want to lose the previous sorting
* for this, includes a new method in the `Context` class called "reset" which deletes all intermediate files associated to the context and creates a fresh `Bunch()` instance for `context.intermediate`.